### PR TITLE
fix: correct refresh token expiration constant in jwt configuration

### DIFF
--- a/src/shared/constants/jwt.constants.ts
+++ b/src/shared/constants/jwt.constants.ts
@@ -2,5 +2,5 @@ export const jwtConstants = {
     secret: process.env.APP_SECRET,
     expiresIn: process.env.EXPIRES_IN,
     refreshTokenSecret: process.env.REFRESH_TOKEN_SECRET,
-    refreshTokenExpiresIn: process.env.EXPIRES_IN,
+    refreshTokenExpiresIn: process.env.REFRESH_TOKEN_EXPIRES_IN,
 };


### PR DESCRIPTION
- Updated the refreshTokenExpiresIn property to use the correct environment variable REFRESH_TOKEN_EXPIRES_IN instead of EXPIRES_IN.