### PR TITLE
feat: add hasGeolocation field to Ranking model and update related DTOs

### DIFF
--- a/prisma/migrations/20250113130000_add_has_geolocation_to_ranking/migration.sql
+++ b/prisma/migrations/20250113130000_add_has_geolocation_to_ranking/migration.sql
@@ -1,0 +1,2 @@
+-- AddHasGeolocationToRanking
+ALTER TABLE "Ranking" ADD COLUMN "hasGeolocation" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -34,6 +34,7 @@ model Ranking {
   name            String
   description     String?
   bannerId        String?
+  hasGeolocation  Boolean           @default(false)
   createdAt       DateTime          @default(now())
   updatedAt       DateTime          @updatedAt
   banner          File?             @relation(fields: [bannerId], references: [id])

--- a/src/ranking/controllers/ranking.controller.ts
+++ b/src/ranking/controllers/ranking.controller.ts
@@ -46,6 +46,7 @@ export class RankingController {
         name: { type: 'string', example: 'Ranking XPTO' },
         description: { type: 'string', example: 'Descrição do ranking' },
         banner: { type: 'string', example: 'https://cdn.com/banner.jpg' },
+        hasGeolocation: { type: 'boolean', example: true },
         createdAt: { type: 'string', format: 'date-time', example: '2024-07-01T12:00:00.000Z' },
       },
       example: {
@@ -53,6 +54,7 @@ export class RankingController {
         name: 'Ranking XPTO',
         description: 'Descrição do ranking',
         banner: 'https://cdn.com/banner.jpg',
+        hasGeolocation: true,
         createdAt: '2024-07-01T12:00:00.000Z',
       },
     },
@@ -301,6 +303,17 @@ export class RankingController {
   @ApiResponse({
     status: 200,
     description: 'Ranking updated successfully',
+    schema: {
+      properties: {
+        id: { type: 'string', example: 'ranking-123' },
+        name: { type: 'string', example: 'Updated Ranking Name' },
+        description: { type: 'string', example: 'Updated description' },
+        hasGeolocation: { type: 'boolean', example: true },
+        ownerId: { type: 'string', example: 'user-123' },
+        createdAt: { type: 'string', format: 'date-time' },
+        updatedAt: { type: 'string', format: 'date-time' },
+      },
+    },
   })
   @ApiResponse({
     status: 404,

--- a/src/ranking/dto/create-ranking.dto.ts
+++ b/src/ranking/dto/create-ranking.dto.ts
@@ -1,4 +1,4 @@
-import { IsNotEmpty, IsOptional, IsString } from 'class-validator';
+import { IsNotEmpty, IsOptional, IsString, IsBoolean } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 
 export default class CreateRankingDto {
@@ -28,7 +28,19 @@ export default class CreateRankingDto {
     required: false,
   })
   @IsOptional()
-  readonly photo: string;
+  readonly photo?: string;
+
+  @ApiProperty({
+    description: 'Whether ranking items can have geolocation (latitude/longitude)',
+    example: true,
+    required: false,
+    default: false,
+  })
+  @IsOptional()
+  @IsBoolean({
+    message: 'hasGeolocation deve ser um valor booleano',
+  })
+  readonly hasGeolocation?: boolean;
 
   @ApiProperty({
     description: 'Owner ID (automatically set from JWT token)',

--- a/src/ranking/dto/update-ranking.dto.ts
+++ b/src/ranking/dto/update-ranking.dto.ts
@@ -1,4 +1,4 @@
-import { IsNotEmpty, IsOptional, IsString } from 'class-validator';
+import { IsNotEmpty, IsOptional, IsString, IsBoolean } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 
 export default class UpdateRankingDto {
@@ -14,7 +14,7 @@ export default class UpdateRankingDto {
     message: 'Nome não pode ser vazio 💁',
   })
   @IsOptional()
-  readonly name: string;
+  readonly name?: string;
 
   @ApiProperty({
     description: 'Ranking description',
@@ -22,7 +22,7 @@ export default class UpdateRankingDto {
     required: false,
   })
   @IsOptional()
-  readonly description: string;
+  readonly description?: string;
 
   @ApiProperty({
     description: 'Ranking banner photo',
@@ -30,5 +30,16 @@ export default class UpdateRankingDto {
     required: false,
   })
   @IsOptional()
-  readonly photo: string;
+  readonly photo?: string;
+
+  @ApiProperty({
+    description: 'Whether ranking items can have geolocation (latitude/longitude)',
+    example: true,
+    required: false,
+  })
+  @IsOptional()
+  @IsBoolean({
+    message: 'hasGeolocation deve ser um valor booleano',
+  })
+  readonly hasGeolocation?: boolean;
 }

--- a/src/ranking/services/ranking-validations.service.spec.ts
+++ b/src/ranking/services/ranking-validations.service.spec.ts
@@ -1,0 +1,142 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { RankingValidationsService } from './ranking-validations.service';
+import { UserRepository } from '../../user/repositories/user.repository';
+import { RankingRepository } from '../repositories/ranking.repository';
+import { RankingUserRepository } from '../repositories/ranking-user.repository';
+import { BadRequestException } from '@nestjs/common';
+
+describe('RankingValidationsService', () => {
+  let service: RankingValidationsService;
+  let userRepository: jest.Mocked<UserRepository>;
+  let rankingRepository: jest.Mocked<RankingRepository>;
+  let rankingUserRepository: jest.Mocked<RankingUserRepository>;
+
+  beforeEach(async () => {
+    const mockUserRepository = {
+      findOne: jest.fn(),
+    };
+
+    const mockRankingRepository = {
+      getRankingById: jest.fn(),
+    };
+
+    const mockRankingUserRepository = {
+      getRankingUsers: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        RankingValidationsService,
+        {
+          provide: UserRepository,
+          useValue: mockUserRepository,
+        },
+        {
+          provide: RankingRepository,
+          useValue: mockRankingRepository,
+        },
+        {
+          provide: RankingUserRepository,
+          useValue: mockRankingUserRepository,
+        },
+      ],
+    }).compile();
+
+    service = module.get<RankingValidationsService>(RankingValidationsService);
+    userRepository = module.get(UserRepository);
+    rankingRepository = module.get(RankingRepository);
+    rankingUserRepository = module.get(RankingUserRepository);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('existUser', () => {
+    it('should return user when user exists', async () => {
+      const userId = 'user-123';
+      const mockUser = {
+        id: 'user-123',
+        name: 'Test User',
+        email: 'test@example.com',
+      };
+
+      userRepository.findOne.mockResolvedValue(mockUser as any);
+
+      const result = await service.existUser(userId);
+
+      expect(userRepository.findOne).toHaveBeenCalledWith({ id: userId });
+      expect(result).toEqual(mockUser);
+    });
+
+    it('should throw BadRequestException when user does not exist', async () => {
+      const userId = 'user-123';
+
+      userRepository.findOne.mockResolvedValue(null);
+
+      await expect(service.existUser(userId)).rejects.toThrow(
+        new BadRequestException('Usuário não encontrado 🕵️‍♂️'),
+      );
+    });
+  });
+
+  describe('existRanking', () => {
+    it('should return ranking when ranking exists', async () => {
+      const rankingId = 'ranking-123';
+      const mockRanking = {
+        id: 'ranking-123',
+        name: 'Test Ranking',
+        ownerId: 'user-123',
+      };
+
+      rankingRepository.getRankingById.mockResolvedValue(mockRanking as any);
+
+      const result = await service.existRanking(rankingId);
+
+      expect(rankingRepository.getRankingById).toHaveBeenCalledWith(rankingId);
+      expect(result).toEqual(mockRanking);
+    });
+
+    it('should throw BadRequestException when ranking does not exist', async () => {
+      const rankingId = 'ranking-123';
+
+      rankingRepository.getRankingById.mockResolvedValue(null);
+
+      await expect(service.existRanking(rankingId)).rejects.toThrow(
+        new BadRequestException('Ranking não encontrado 🕵️‍♂️'),
+      );
+    });
+  });
+
+  describe('existRankingUser', () => {
+    it('should return ranking users when user is part of ranking', async () => {
+      const rankingId = 'ranking-123';
+      const userId = 'user-123';
+      const mockRankingUsers = [
+        {
+          id: 'user-ranking-123',
+          userId: 'user-123',
+          rankingId: 'ranking-123',
+        },
+      ];
+
+      rankingUserRepository.getRankingUsers.mockResolvedValue(mockRankingUsers as any);
+
+      const result = await service.existRankingUser(rankingId, userId);
+
+      expect(rankingUserRepository.getRankingUsers).toHaveBeenCalledWith(rankingId);
+      expect(result).toEqual(mockRankingUsers);
+    });
+
+    it('should throw BadRequestException when user is not part of ranking', async () => {
+      const rankingId = 'ranking-123';
+      const userId = 'user-123';
+
+      rankingUserRepository.getRankingUsers.mockResolvedValue([]);
+
+      await expect(service.existRankingUser(rankingId, userId)).rejects.toThrow(
+        new BadRequestException('Usuário não faz parte do ranking 🕵️‍♂️'),
+      );
+    });
+  });
+});

--- a/src/ranking/services/ranking.service.spec.ts
+++ b/src/ranking/services/ranking.service.spec.ts
@@ -4,9 +4,16 @@ import { RankingRepository } from '../repositories/ranking.repository';
 import { RankingValidationsService } from './ranking-validations.service';
 import { OpenAiService } from '../../ai/services/openai.service';
 import { BucketService } from '../../shared/services/bucket.service';
+import { BadRequestException } from '@nestjs/common';
+import CreateRankingDto from '../dto/create-ranking.dto';
+import UpdateRankingDto from '../dto/update-ranking.dto';
 
 describe('RankingService', () => {
   let service: RankingService;
+  let rankingRepository: jest.Mocked<RankingRepository>;
+  let rankingValidationService: jest.Mocked<RankingValidationsService>;
+  let openAiService: jest.Mocked<OpenAiService>;
+  let bucketService: jest.Mocked<BucketService>;
 
   beforeEach(async () => {
     const mockRankingRepository = {
@@ -54,9 +61,219 @@ describe('RankingService', () => {
     }).compile();
 
     service = module.get<RankingService>(RankingService);
+    rankingRepository = module.get(RankingRepository);
+    rankingValidationService = module.get(RankingValidationsService);
+    openAiService = module.get(OpenAiService);
+    bucketService = module.get(BucketService);
   });
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  describe('createRanking', () => {
+    it('should create a ranking successfully', async () => {
+      const createRankingDto: CreateRankingDto = {
+        name: 'Test Ranking',
+        description: 'Test Description',
+        ownerId: 'user-123',
+        hasGeolocation: true,
+      };
+
+      const mockUser = { 
+        id: 'user-123', 
+        name: 'Test User',
+        email: 'test@example.com',
+        password: 'hashedPassword',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        refreshToken: null,
+        pushToken: null,
+        avatarId: null,
+      };
+      const mockRanking = {
+        id: 'ranking-123',
+        name: 'Test Ranking',
+        description: 'Test Description',
+        hasGeolocation: true,
+        ownerId: 'user-123',
+        bannerId: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      rankingValidationService.existUser.mockResolvedValue(mockUser as any);
+      rankingRepository.createRanking.mockResolvedValue(mockRanking as any);
+
+      const result = await service.createRanking(createRankingDto);
+
+      expect(rankingValidationService.existUser).toHaveBeenCalledWith('user-123');
+      expect(rankingRepository.createRanking).toHaveBeenCalledWith({
+        name: 'Test Ranking',
+        ownerId: 'user-123',
+        description: 'Test Description',
+        hasGeolocation: true,
+      });
+      expect(result).toEqual(mockRanking);
+    });
+
+    it('should create a ranking with default hasGeolocation false', async () => {
+      const createRankingDto: CreateRankingDto = {
+        name: 'Test Ranking',
+        description: 'Test Description',
+        ownerId: 'user-123',
+      };
+
+      const mockUser = { 
+        id: 'user-123', 
+        name: 'Test User',
+        email: 'test@example.com',
+        password: 'hashedPassword',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        refreshToken: null,
+        pushToken: null,
+        avatarId: null,
+      };
+      const mockRanking = {
+        id: 'ranking-123',
+        name: 'Test Ranking',
+        description: 'Test Description',
+        hasGeolocation: false,
+        ownerId: 'user-123',
+        bannerId: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      rankingValidationService.existUser.mockResolvedValue(mockUser as any);
+      rankingRepository.createRanking.mockResolvedValue(mockRanking as any);
+
+      const result = await service.createRanking(createRankingDto);
+
+      expect(rankingRepository.createRanking).toHaveBeenCalledWith({
+        name: 'Test Ranking',
+        ownerId: 'user-123',
+        description: 'Test Description',
+        hasGeolocation: false,
+      });
+      expect(result).toEqual(mockRanking);
+    });
+
+    it('should throw BadRequestException when user does not exist', async () => {
+      const createRankingDto: CreateRankingDto = {
+        name: 'Test Ranking',
+        description: 'Test Description',
+        ownerId: 'user-123',
+      };
+
+      rankingValidationService.existUser.mockRejectedValue(
+        new BadRequestException('User not found'),
+      );
+
+      await expect(service.createRanking(createRankingDto)).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('should throw BadRequestException when repository fails', async () => {
+      const createRankingDto: CreateRankingDto = {
+        name: 'Test Ranking',
+        description: 'Test Description',
+        ownerId: 'user-123',
+      };
+
+      const mockUser = { 
+        id: 'user-123', 
+        name: 'Test User',
+        email: 'test@example.com',
+        password: 'hashedPassword',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        refreshToken: null,
+        pushToken: null,
+        avatarId: null,
+      };
+
+      rankingValidationService.existUser.mockResolvedValue(mockUser as any);
+      rankingRepository.createRanking.mockRejectedValue(new Error('Database error'));
+
+      await expect(service.createRanking(createRankingDto)).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+  });
+
+  describe('updateRanking', () => {
+    it('should update a ranking successfully', async () => {
+      const rankingId = 'ranking-123';
+      const updateData: UpdateRankingDto = {
+        name: 'Updated Ranking',
+        description: 'Updated Description',
+        hasGeolocation: true,
+      };
+
+      const mockRanking = {
+        id: 'ranking-123',
+        name: 'Updated Ranking',
+        description: 'Updated Description',
+        hasGeolocation: true,
+        ownerId: 'user-123',
+        bannerId: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      rankingValidationService.existRanking.mockResolvedValue(undefined as any);
+      rankingRepository.updateRanking.mockResolvedValue(mockRanking as any);
+
+      const result = await service.updateRanking(rankingId, updateData);
+
+      expect(rankingValidationService.existRanking).toHaveBeenCalledWith(rankingId);
+      expect(rankingRepository.updateRanking).toHaveBeenCalledWith(rankingId, updateData);
+      expect(result).toEqual(mockRanking);
+    });
+
+    it('should update ranking with partial data', async () => {
+      const rankingId = 'ranking-123';
+      const updateData: UpdateRankingDto = {
+        hasGeolocation: false,
+      };
+
+      const mockRanking = {
+        id: 'ranking-123',
+        name: 'Original Ranking',
+        description: 'Original Description',
+        hasGeolocation: false,
+        ownerId: 'user-123',
+        bannerId: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      rankingValidationService.existRanking.mockResolvedValue(undefined as any);
+      rankingRepository.updateRanking.mockResolvedValue(mockRanking as any);
+
+      const result = await service.updateRanking(rankingId, updateData);
+
+      expect(rankingValidationService.existRanking).toHaveBeenCalledWith(rankingId);
+      expect(rankingRepository.updateRanking).toHaveBeenCalledWith(rankingId, updateData);
+      expect(result).toEqual(mockRanking);
+    });
+
+    it('should throw BadRequestException when ranking does not exist', async () => {
+      const rankingId = 'ranking-123';
+      const updateData: UpdateRankingDto = {
+        name: 'Updated Ranking',
+      };
+
+      rankingValidationService.existRanking.mockRejectedValue(
+        new BadRequestException('Ranking not found'),
+      );
+
+      await expect(service.updateRanking(rankingId, updateData)).rejects.toThrow(
+        BadRequestException,
+      );
+    });
   });
 });

--- a/src/ranking/services/ranking.service.ts
+++ b/src/ranking/services/ranking.service.ts
@@ -27,6 +27,7 @@ export class RankingService {
         name: createRankingDto.name,
         ownerId: owner.id,
         description: createRankingDto.description,
+        hasGeolocation: createRankingDto.hasGeolocation || false,
       });
     } catch (error) {
       if (error instanceof BadRequestException) {
@@ -41,8 +42,9 @@ export class RankingService {
     try {
       Logger.log('Validate exist ranking', 'RankingService.updateRanking');
       await this.rankingValidationService.existRanking(rankingId);
-      await this.rankingRepository.updateRanking(rankingId, data);
+      const updatedRanking = await this.rankingRepository.updateRanking(rankingId, data);
       Logger.log('Ranking updated', 'RankingService.updateRanking');
+      return updatedRanking;
     } catch (error) {
       if (error instanceof BadRequestException) {
         throw error;

--- a/src/shared/services/encrypt.service.spec.ts
+++ b/src/shared/services/encrypt.service.spec.ts
@@ -1,0 +1,90 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { EncryptService } from './encrypt.service';
+import * as bcrypt from 'bcryptjs';
+
+// Mock bcryptjs
+jest.mock('bcryptjs', () => ({
+  hash: jest.fn(),
+  compare: jest.fn(),
+}));
+
+describe('EncryptService', () => {
+  let service: EncryptService;
+  let mockBcrypt: jest.Mocked<typeof bcrypt>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [EncryptService],
+    }).compile();
+
+    service = module.get<EncryptService>(EncryptService);
+    mockBcrypt = bcrypt as jest.Mocked<typeof bcrypt>;
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('hash', () => {
+    it('should hash a password successfully', async () => {
+      const password = 'testPassword123';
+      const hashedPassword = 'hashedPassword123';
+
+      mockBcrypt.hash.mockResolvedValue(hashedPassword as never);
+
+      const result = await service.hash(password);
+
+      expect(mockBcrypt.hash).toHaveBeenCalledWith(password, 8);
+      expect(result).toBe(hashedPassword);
+    });
+
+    it('should handle hash errors', async () => {
+      const password = 'testPassword123';
+      const error = new Error('Hash failed');
+
+      mockBcrypt.hash.mockRejectedValue(error as never);
+
+      await expect(service.hash(password)).rejects.toThrow('Hash failed');
+    });
+  });
+
+  describe('compare', () => {
+    it('should compare passwords successfully - match', async () => {
+      const rawPassword = 'testPassword123';
+      const hashedPassword = 'hashedPassword123';
+
+      mockBcrypt.compare.mockResolvedValue(true as never);
+
+      const result = await service.compare(rawPassword, hashedPassword);
+
+      expect(mockBcrypt.compare).toHaveBeenCalledWith(rawPassword, hashedPassword);
+      expect(result).toBe(true);
+    });
+
+    it('should compare passwords successfully - no match', async () => {
+      const rawPassword = 'testPassword123';
+      const hashedPassword = 'hashedPassword123';
+
+      mockBcrypt.compare.mockResolvedValue(false as never);
+
+      const result = await service.compare(rawPassword, hashedPassword);
+
+      expect(mockBcrypt.compare).toHaveBeenCalledWith(rawPassword, hashedPassword);
+      expect(result).toBe(false);
+    });
+
+    it('should handle compare errors', async () => {
+      const rawPassword = 'testPassword123';
+      const hashedPassword = 'hashedPassword123';
+      const error = new Error('Compare failed');
+
+      mockBcrypt.compare.mockRejectedValue(error as never);
+
+      await expect(service.compare(rawPassword, hashedPassword)).rejects.toThrow('Compare failed');
+    });
+  });
+});

--- a/src/shared/services/expo-push.service.spec.ts
+++ b/src/shared/services/expo-push.service.spec.ts
@@ -1,0 +1,175 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ExpoPushService } from './expo-push.service';
+import { Expo } from 'expo-server-sdk';
+
+// Mock expo-server-sdk
+jest.mock('expo-server-sdk', () => ({
+  Expo: jest.fn().mockImplementation(() => ({
+    isExpoPushToken: jest.fn(),
+    sendPushNotificationsAsync: jest.fn(),
+  })),
+}));
+
+describe('ExpoPushService', () => {
+  let service: ExpoPushService;
+  let mockExpo: jest.Mocked<Expo>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [ExpoPushService],
+    }).compile();
+
+    service = module.get<ExpoPushService>(ExpoPushService);
+    mockExpo = service['expo'] as jest.Mocked<Expo>;
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('sendPushNotification', () => {
+    it('should send push notification successfully', async () => {
+      const expoPushToken = 'ExponentPushToken[xxxxxxxxxxxxxxxxxxxxxx]';
+      const title = 'Test Title';
+      const body = 'Test Body';
+
+      mockExpo.isExpoPushToken.mockReturnValue(true);
+      mockExpo.sendPushNotificationsAsync.mockResolvedValue([{ status: 'ok' }] as any);
+
+      await service.sendPushNotification(expoPushToken, title, body);
+
+      expect(mockExpo.isExpoPushToken).toHaveBeenCalledWith(expoPushToken);
+      expect(mockExpo.sendPushNotificationsAsync).toHaveBeenCalledWith([
+        {
+          to: expoPushToken,
+          sound: 'default',
+          title,
+          body,
+        },
+      ]);
+    });
+
+    it('should not send notification for invalid token', async () => {
+      const expoPushToken = 'invalid-token';
+      const title = 'Test Title';
+      const body = 'Test Body';
+
+      mockExpo.isExpoPushToken.mockReturnValue(false);
+
+      await service.sendPushNotification(expoPushToken, title, body);
+
+      expect(mockExpo.isExpoPushToken).toHaveBeenCalledWith(expoPushToken);
+      expect(mockExpo.sendPushNotificationsAsync).not.toHaveBeenCalled();
+    });
+
+    it('should handle send notification errors', async () => {
+      const expoPushToken = 'ExponentPushToken[xxxxxxxxxxxxxxxxxxxxxx]';
+      const title = 'Test Title';
+      const body = 'Test Body';
+      const error = new Error('Push notification failed');
+
+      mockExpo.isExpoPushToken.mockReturnValue(true);
+      mockExpo.sendPushNotificationsAsync.mockRejectedValue(error);
+
+      // Should not throw error, just log it
+      await expect(service.sendPushNotification(expoPushToken, title, body)).resolves.toBeUndefined();
+    });
+  });
+
+  describe('sendBulkPushNotifications', () => {
+    it('should send bulk push notifications successfully', async () => {
+      const expoPushTokens = [
+        'ExponentPushToken[xxxxxxxxxxxxxxxxxxxxxx]',
+        'ExponentPushToken[yyyyyyyyyyyyyyyyyyyyyy]',
+      ];
+      const title = 'Test Title';
+      const body = 'Test Body';
+
+      mockExpo.isExpoPushToken.mockReturnValue(true);
+      mockExpo.sendPushNotificationsAsync.mockResolvedValue([
+        { status: 'ok' },
+        { status: 'ok' },
+      ] as any);
+
+      await service.sendBulkPushNotifications(expoPushTokens, title, body);
+
+      expect(mockExpo.sendPushNotificationsAsync).toHaveBeenCalledWith([
+        {
+          to: expoPushTokens[0],
+          sound: 'default',
+          title,
+          body,
+        },
+        {
+          to: expoPushTokens[1],
+          sound: 'default',
+          title,
+          body,
+        },
+      ]);
+    });
+
+    it('should filter out invalid tokens', async () => {
+      const expoPushTokens = [
+        'ExponentPushToken[xxxxxxxxxxxxxxxxxxxxxx]',
+        'invalid-token',
+        'ExponentPushToken[yyyyyyyyyyyyyyyyyyyyyy]',
+      ];
+      const title = 'Test Title';
+      const body = 'Test Body';
+
+      mockExpo.isExpoPushToken
+        .mockReturnValueOnce(true)
+        .mockReturnValueOnce(false)
+        .mockReturnValueOnce(true);
+      mockExpo.sendPushNotificationsAsync.mockResolvedValue([
+        { status: 'ok' },
+        { status: 'ok' },
+      ] as any);
+
+      await service.sendBulkPushNotifications(expoPushTokens, title, body);
+
+      expect(mockExpo.sendPushNotificationsAsync).toHaveBeenCalledWith([
+        {
+          to: expoPushTokens[0],
+          sound: 'default',
+          title,
+          body,
+        },
+        {
+          to: expoPushTokens[2],
+          sound: 'default',
+          title,
+          body,
+        },
+      ]);
+    });
+
+    it('should handle empty tokens array', async () => {
+      const expoPushTokens: string[] = [];
+      const title = 'Test Title';
+      const body = 'Test Body';
+
+      await service.sendBulkPushNotifications(expoPushTokens, title, body);
+
+      expect(mockExpo.sendPushNotificationsAsync).not.toHaveBeenCalled();
+    });
+
+    it('should handle send bulk notification errors', async () => {
+      const expoPushTokens = ['ExponentPushToken[xxxxxxxxxxxxxxxxxxxxxx]'];
+      const title = 'Test Title';
+      const body = 'Test Body';
+      const error = new Error('Bulk push notification failed');
+
+      mockExpo.isExpoPushToken.mockReturnValue(true);
+      mockExpo.sendPushNotificationsAsync.mockRejectedValue(error);
+
+      // Should not throw error, just log it
+      await expect(service.sendBulkPushNotifications(expoPushTokens, title, body)).resolves.toBeUndefined();
+    });
+  });
+});

--- a/src/shared/utils/format.util.spec.ts
+++ b/src/shared/utils/format.util.spec.ts
@@ -1,0 +1,106 @@
+import { formatPhone, formatCPF, formatCNPJ, formatCEP, formatRG, formatDateOfBirth } from './format.util';
+
+describe('FormatUtil', () => {
+  describe('formatPhone', () => {
+    it('should format phone with 11 digits', () => {
+      const phone = '11987654321';
+      const result = formatPhone(phone);
+      
+      expect(result).toBe('(11) 98765-4321');
+    });
+
+    it('should format phone with 10 digits', () => {
+      const phone = '1134567890';
+      const result = formatPhone(phone);
+      
+      expect(result).toBe('(11) 3456-7890');
+    });
+
+    it('should return empty string for empty input', () => {
+      const phone = '';
+      const result = formatPhone(phone);
+      
+      expect(result).toBe('');
+    });
+  });
+
+  describe('formatCPF', () => {
+    it('should format CPF correctly', () => {
+      const cpf = '12345678901';
+      const result = formatCPF(cpf);
+      
+      expect(result).toBe('123.456.789-01');
+    });
+
+    it('should return empty string for empty input', () => {
+      const cpf = '';
+      const result = formatCPF(cpf);
+      
+      expect(result).toBe('');
+    });
+  });
+
+  describe('formatCNPJ', () => {
+    it('should format CNPJ correctly', () => {
+      const cnpj = '12345678000195';
+      const result = formatCNPJ(cnpj);
+      
+      expect(result).toBe('12.345.678/0001-95');
+    });
+
+    it('should return empty string for empty input', () => {
+      const cnpj = '';
+      const result = formatCNPJ(cnpj);
+      
+      expect(result).toBe('');
+    });
+  });
+
+  describe('formatCEP', () => {
+    it('should format CEP correctly', () => {
+      const cep = '12345678';
+      const result = formatCEP(cep);
+      
+      expect(result).toBe('12345-678');
+    });
+
+    it('should return empty string for empty input', () => {
+      const cep = '';
+      const result = formatCEP(cep);
+      
+      expect(result).toBe('');
+    });
+  });
+
+  describe('formatRG', () => {
+    it('should format RG correctly', () => {
+      const rg = '123456789';
+      const result = formatRG(rg);
+      
+      expect(result).toBe('12.345.678-9');
+    });
+
+    it('should return empty string for empty input', () => {
+      const rg = '';
+      const result = formatRG(rg);
+      
+      expect(result).toBe('');
+    });
+  });
+
+  describe('formatDateOfBirth', () => {
+    it('should format date of birth correctly', () => {
+      const date = '15012000';
+      const result = formatDateOfBirth(date);
+      
+      expect(result).toBe('15/01/2000');
+    });
+
+    it('should return empty string for empty input', () => {
+      const date = '';
+      const result = formatDateOfBirth(date);
+      
+      expect(result).toBe('');
+    });
+  });
+});

--- a/src/shared/utils/paginator.util.spec.ts
+++ b/src/shared/utils/paginator.util.spec.ts
@@ -1,0 +1,105 @@
+import { paginator, PaginateOptions, PaginatedResult } from './paginator.util';
+
+describe('PaginatorUtil', () => {
+  describe('paginator', () => {
+    let mockModel: any;
+    let paginateFunction: any;
+
+    beforeEach(() => {
+      mockModel = {
+        count: jest.fn(),
+        findMany: jest.fn(),
+      };
+
+      const defaultOptions: PaginateOptions = {
+        page: 1,
+        perPage: 10,
+      };
+
+      paginateFunction = paginator(defaultOptions);
+    });
+
+    it('should paginate data correctly', async () => {
+      const mockData = [{ id: 1 }, { id: 2 }, { id: 3 }];
+      const mockTotal = 25;
+
+      mockModel.count.mockResolvedValue(mockTotal);
+      mockModel.findMany.mockResolvedValue(mockData);
+
+      const result = await paginateFunction(mockModel, { where: {} }, { page: 2, perPage: 10 });
+
+      expect(mockModel.count).toHaveBeenCalledWith({ where: {} });
+      expect(mockModel.findMany).toHaveBeenCalledWith({
+        where: {},
+        take: 10,
+        skip: 10,
+      });
+
+      expect(result).toEqual({
+        data: mockData,
+        meta: {
+          total: mockTotal,
+          lastPage: 3,
+          currentPage: 2,
+          perPage: 10,
+          prev: 1,
+          next: 3,
+        },
+      });
+    });
+
+    it('should use default options when not provided', async () => {
+      const mockData = [{ id: 1 }];
+      const mockTotal = 5;
+
+      mockModel.count.mockResolvedValue(mockTotal);
+      mockModel.findMany.mockResolvedValue(mockData);
+
+      const result = await paginateFunction(mockModel);
+
+      expect(mockModel.findMany).toHaveBeenCalledWith({
+        where: undefined,
+        take: 10,
+        skip: 0,
+      });
+
+      expect(result.meta.currentPage).toBe(1);
+      expect(result.meta.perPage).toBe(10);
+    });
+
+    it('should handle empty results', async () => {
+      const mockData: any[] = [];
+      const mockTotal = 0;
+
+      mockModel.count.mockResolvedValue(mockTotal);
+      mockModel.findMany.mockResolvedValue(mockData);
+
+      const result = await paginateFunction(mockModel, { where: {} });
+
+      expect(result).toEqual({
+        data: [],
+        meta: {
+          total: 0,
+          lastPage: 0,
+          currentPage: 1,
+          perPage: 10,
+          prev: null,
+          next: null,
+        },
+      });
+    });
+
+    it('should handle last page correctly', async () => {
+      const mockData = [{ id: 1 }];
+      const mockTotal = 25;
+
+      mockModel.count.mockResolvedValue(mockTotal);
+      mockModel.findMany.mockResolvedValue(mockData);
+
+      const result = await paginateFunction(mockModel, { where: {} }, { page: 3, perPage: 10 });
+
+      expect(result.meta.next).toBe(null);
+      expect(result.meta.prev).toBe(2);
+    });
+  });
+});


### PR DESCRIPTION
- Introduced `hasGeolocation` boolean field in the `Ranking` model with a default value of false.
- Updated `CreateRankingDto` and `UpdateRankingDto` to include `hasGeolocation` property with validation.
- Modified `RankingController` to handle `hasGeolocation` in API responses.
- Added migration script to reflect the new column in the database.
- Enhanced unit tests for ranking service to cover new geolocation functionality.