### PR TITLE
feat: enhance geolocation validation in ranking item DTOs

### DIFF
--- a/src/ranking/dto/create-ranking-item.dto.ts
+++ b/src/ranking/dto/create-ranking-item.dto.ts
@@ -1,4 +1,4 @@
-import { IsArray, IsNotEmpty, IsOptional, IsString } from 'class-validator';
+import { IsArray, IsNotEmpty, IsOptional, IsString, IsNumberString, IsLatitude, IsLongitude } from 'class-validator';
 
 export default class CreateRankingItemDto {
   rankingId: string;
@@ -14,6 +14,9 @@ export default class CreateRankingItemDto {
   createdById: string;
 
   @IsOptional()
+  @IsString({
+    message: 'Descrição inválida 🙈',
+  })
   readonly description?: string;
 
   @IsOptional()
@@ -23,11 +26,38 @@ export default class CreateRankingItemDto {
   readonly photos?: string[];
 
   @IsOptional()
+  @IsString({
+    message: 'Link inválido 🙈',
+  })
   readonly link?: string;
 
   @IsOptional()
+  @IsString({
+    message: 'Latitude deve ser uma string 🙈',
+  })
+  @IsNumberString(
+    {},
+    {
+      message: 'Latitude deve ser um número válido 🙈',
+    },
+  )
+  @IsLatitude({
+    message: 'Latitude deve estar entre -90 e 90 graus 🙈',
+  })
   readonly latitude?: string;
 
   @IsOptional()
+  @IsString({
+    message: 'Longitude deve ser uma string 🙈',
+  })
+  @IsNumberString(
+    {},
+    {
+      message: 'Longitude deve ser um número válido 🙈',
+    },
+  )
+  @IsLongitude({
+    message: 'Longitude deve estar entre -180 e 180 graus 🙈',
+  })
   readonly longitude?: string;
 }

--- a/src/ranking/dto/update-ranking-item.dto.ts
+++ b/src/ranking/dto/update-ranking-item.dto.ts
@@ -1,4 +1,4 @@
-import { IsArray, IsOptional, IsString } from 'class-validator';
+import { IsArray, IsOptional, IsString, IsNumberString, IsLatitude, IsLongitude } from 'class-validator';
 
 export default class UpdateRankingItemDto {
   @IsOptional()
@@ -8,6 +8,9 @@ export default class UpdateRankingItemDto {
   readonly name?: string;
 
   @IsOptional()
+  @IsString({
+    message: 'Descrição inválida 🙈',
+  })
   readonly description?: string;
 
   @IsOptional()
@@ -17,12 +20,39 @@ export default class UpdateRankingItemDto {
   readonly photos?: string[];
 
   @IsOptional()
+  @IsString({
+    message: 'Link inválido 🙈',
+  })
   readonly link?: string;
 
   @IsOptional()
+  @IsString({
+    message: 'Latitude deve ser uma string 🙈',
+  })
+  @IsNumberString(
+    {},
+    {
+      message: 'Latitude deve ser um número válido 🙈',
+    },
+  )
+  @IsLatitude({
+    message: 'Latitude deve estar entre -90 e 90 graus 🙈',
+  })
   readonly latitude?: string;
 
   @IsOptional()
+  @IsString({
+    message: 'Longitude deve ser uma string 🙈',
+  })
+  @IsNumberString(
+    {},
+    {
+      message: 'Longitude deve ser um número válido 🙈',
+    },
+  )
+  @IsLongitude({
+    message: 'Longitude deve estar entre -180 e 180 graus 🙈',
+  })
   readonly longitude?: string;
 }
 

--- a/src/ranking/services/ranking-item.service.spec.ts
+++ b/src/ranking/services/ranking-item.service.spec.ts
@@ -245,6 +245,46 @@ describe('RankingItemService', () => {
       });
       expect(result).toEqual(expectedResult);
     });
+
+    it('should create a ranking item with empty string geolocation', async () => {
+      const createRankingItemDto: CreateRankingItemDto = {
+        rankingId: 'ranking-id',
+        name: 'Test Item with Empty Location',
+        description: 'Test Description',
+        createdById: 'user-id',
+        latitude: '',
+        longitude: '',
+      };
+
+      const expectedResult = {
+        id: 'item-id',
+        rankingId: 'ranking-id',
+        name: 'Test Item with Empty Location',
+        description: 'Test Description',
+        createdById: 'user-id',
+        latitude: null,
+        longitude: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      mockRankingValidationsService.existUser.mockResolvedValue(undefined);
+      mockRankingValidationsService.existRankingUser.mockResolvedValue(undefined);
+      mockRankingItemRepository.createRankingItem.mockResolvedValue(expectedResult);
+
+      const result = await service.createRankingItem(createRankingItemDto);
+
+      expect(rankingItemRepository.createRankingItem).toHaveBeenCalledWith({
+        name: 'Test Item with Empty Location',
+        description: 'Test Description',
+        link: undefined,
+        latitude: null,
+        longitude: null,
+        rankingId: 'ranking-id',
+        createdById: 'user-id',
+      });
+      expect(result).toEqual(expectedResult);
+    });
   });
 
   describe('getRankingItems', () => {
@@ -412,11 +452,158 @@ describe('RankingItemService', () => {
       expect(rankingItemRepository.updateRankingItem).toHaveBeenCalled();
     });
 
+    it('should update a ranking item with geolocation', async () => {
+      const rankingId = 'ranking-id';
+      const rankingItemId = 'item-id';
+      const userId = 'user-id';
+      const updateDto = {
+        name: 'Updated Item',
+        latitude: '-23.5505',
+        longitude: '-46.6333',
+      } as any;
+
+      const mockItem = {
+        id: rankingItemId,
+        rankingId,
+      } as any;
+
+      const expected = {
+        id: rankingItemId,
+        name: 'Updated Item',
+        latitude: -23.5505,
+        longitude: -46.6333,
+      } as any;
+
+      mockRankingItemRepository.getRankingItemById.mockResolvedValue(mockItem);
+      mockRankingValidationsService.existRankingUser.mockResolvedValue(undefined);
+      mockRankingItemRepository.updateRankingItem.mockResolvedValue(expected);
+
+      const result = await service.updateRankingItem(
+        rankingId,
+        rankingItemId,
+        userId,
+        updateDto,
+      );
+
+      expect(rankingItemRepository.updateRankingItem).toHaveBeenCalledWith(rankingItemId, {
+        name: 'Updated Item',
+        description: undefined,
+        link: undefined,
+        latitude: -23.5505,
+        longitude: -46.6333,
+      });
+      expect(result).toEqual(expected);
+    });
+
+    it('should update a ranking item with null geolocation when not provided', async () => {
+      const rankingId = 'ranking-id';
+      const rankingItemId = 'item-id';
+      const userId = 'user-id';
+      const updateDto = {
+        name: 'Updated Item',
+        description: 'Updated description',
+      } as any;
+
+      const mockItem = {
+        id: rankingItemId,
+        rankingId,
+      } as any;
+
+      const expected = {
+        id: rankingItemId,
+        name: 'Updated Item',
+        description: 'Updated description',
+        latitude: null,
+        longitude: null,
+      } as any;
+
+      mockRankingItemRepository.getRankingItemById.mockResolvedValue(mockItem);
+      mockRankingValidationsService.existRankingUser.mockResolvedValue(undefined);
+      mockRankingItemRepository.updateRankingItem.mockResolvedValue(expected);
+
+      const result = await service.updateRankingItem(
+        rankingId,
+        rankingItemId,
+        userId,
+        updateDto,
+      );
+
+      expect(rankingItemRepository.updateRankingItem).toHaveBeenCalledWith(rankingItemId, {
+        name: 'Updated Item',
+        description: 'Updated description',
+        link: undefined,
+        latitude: null,
+        longitude: null,
+      });
+      expect(result).toEqual(expected);
+    });
+
+    it('should update a ranking item with empty string geolocation', async () => {
+      const rankingId = 'ranking-id';
+      const rankingItemId = 'item-id';
+      const userId = 'user-id';
+      const updateDto = {
+        name: 'Updated Item',
+        latitude: '',
+        longitude: '',
+      } as any;
+
+      const mockItem = {
+        id: rankingItemId,
+        rankingId,
+      } as any;
+
+      const expected = {
+        id: rankingItemId,
+        name: 'Updated Item',
+        latitude: null,
+        longitude: null,
+      } as any;
+
+      mockRankingItemRepository.getRankingItemById.mockResolvedValue(mockItem);
+      mockRankingValidationsService.existRankingUser.mockResolvedValue(undefined);
+      mockRankingItemRepository.updateRankingItem.mockResolvedValue(expected);
+
+      const result = await service.updateRankingItem(
+        rankingId,
+        rankingItemId,
+        userId,
+        updateDto,
+      );
+
+      expect(rankingItemRepository.updateRankingItem).toHaveBeenCalledWith(rankingItemId, {
+        name: 'Updated Item',
+        description: undefined,
+        link: undefined,
+        latitude: null,
+        longitude: null,
+      });
+      expect(result).toEqual(expected);
+    });
+
     it('should throw if item not found', async () => {
       mockRankingItemRepository.getRankingItemById.mockResolvedValue(null);
       await expect(
         service.updateRankingItem('ranking-id', 'item-id', 'user-id', {} as any),
       ).rejects.toThrow('Item do ranking não encontrado 😔');
+    });
+
+    it('should throw if item does not belong to ranking', async () => {
+      const rankingId = 'ranking-id';
+      const rankingItemId = 'item-id';
+      const userId = 'user-id';
+      const updateDto = { name: 'Updated' } as any;
+
+      const mockItem = {
+        id: rankingItemId,
+        rankingId: 'different-ranking-id',
+      } as any;
+
+      mockRankingItemRepository.getRankingItemById.mockResolvedValue(mockItem);
+
+      await expect(
+        service.updateRankingItem(rankingId, rankingItemId, userId, updateDto),
+      ).rejects.toThrow('Item não pertence a este ranking 😔');
     });
 
     it('should sync photos: add new and remove missing', async () => {

--- a/src/ranking/services/ranking-item.service.ts
+++ b/src/ranking/services/ranking-item.service.ts
@@ -162,8 +162,8 @@ export class RankingItemService {
           name: updateDto.name,
           description: updateDto.description,
           link: updateDto.link,
-          latitude: updateDto.latitude as unknown as number,
-          longitude: updateDto.longitude as unknown as number,
+          latitude: updateDto.latitude ? parseFloat(updateDto.latitude) : null,
+          longitude: updateDto.longitude ? parseFloat(updateDto.longitude) : null,
         },
       );
 


### PR DESCRIPTION
- Added validation for latitude and longitude fields in `CreateRankingItemDto` and `UpdateRankingItemDto` to ensure they are strings and valid numbers.
- Updated service logic to parse latitude and longitude from strings to numbers or set them to null when not provided.
- Enhanced unit tests to cover scenarios for creating and updating ranking items with geolocation, including handling empty strings.