### PR TITLE
feat: add bulk score creation for ranking items

### DIFF
--- a/src/ranking/controllers/ranking-score.controller.spec.ts
+++ b/src/ranking/controllers/ranking-score.controller.spec.ts
@@ -3,6 +3,7 @@ import { RankingScoreController } from './ranking-score.controller';
 import { RankingScoreService } from '../services/ranking-score.service';
 import { AuthGuard } from '@nestjs/passport';
 import CreateRankingItemScoreDto from '../dto/create-ranking-item-score.dto';
+import CreateMultipleRankingItemScoresDto from '../dto/create-multiple-ranking-item-scores.dto';
 
 describe('RankingScoreController', () => {
   let controller: RankingScoreController;
@@ -11,6 +12,7 @@ describe('RankingScoreController', () => {
   const mockRankingScoreService = {
     createRankingScore: jest.fn(),
     getRankingItemScores: jest.fn(),
+    createMultipleRankingScores: jest.fn(),
   };
 
   beforeEach(async () => {
@@ -110,6 +112,104 @@ describe('RankingScoreController', () => {
       const result = await controller.getRankingScores(rankingId, rankingItemId);
 
       expect(service.getRankingItemScores).toHaveBeenCalledWith(rankingItemId);
+      expect(result).toEqual(expectedResult);
+    });
+  });
+
+  describe('createMultipleRankingScores', () => {
+    it('should create multiple ranking scores', async () => {
+      const rankingId = 'ranking-id';
+      const rankingItemId = 'item-id';
+      const createMultipleScoresDto: CreateMultipleRankingItemScoresDto = {
+        rankingItemId: 'item-id',
+        userId: 'user-id',
+        scores: [
+          { rankingCriteriaId: 'criteria-1', score: 8.5 },
+          { rankingCriteriaId: 'criteria-2', score: 9.0 },
+        ],
+      };
+
+      const expectedResult = {
+        message: '2 score(s) processado(s) com sucesso',
+        results: [
+          {
+            id: 'score-1',
+            rankingItemId: 'item-id',
+            userId: 'user-id',
+            rankingCriteriaId: 'criteria-1',
+            score: 8.5,
+            createdAt: new Date(),
+            updatedAt: new Date(),
+            action: 'created',
+          },
+          {
+            id: 'score-2',
+            rankingItemId: 'item-id',
+            userId: 'user-id',
+            rankingCriteriaId: 'criteria-2',
+            score: 9.0,
+            createdAt: new Date(),
+            updatedAt: new Date(),
+            action: 'updated',
+          },
+        ],
+        summary: {
+          created: 1,
+          updated: 1,
+          total: 2,
+        },
+      };
+
+      mockRankingScoreService.createMultipleRankingScores.mockResolvedValue(expectedResult);
+
+      const result = await controller.createMultipleRankingScores(
+        rankingId,
+        rankingItemId,
+        createMultipleScoresDto,
+        'user-id'
+      );
+
+      expect(service.createMultipleRankingScores).toHaveBeenCalledWith({
+        ...createMultipleScoresDto,
+        rankingItemId: 'item-id',
+        userId: 'user-id',
+      });
+      expect(result).toEqual(expectedResult);
+    });
+
+    it('should handle empty scores array', async () => {
+      const rankingId = 'ranking-id';
+      const rankingItemId = 'item-id';
+      const createMultipleScoresDto: CreateMultipleRankingItemScoresDto = {
+        rankingItemId: 'item-id',
+        userId: 'user-id',
+        scores: [],
+      };
+
+      const expectedResult = {
+        message: '0 score(s) processado(s) com sucesso',
+        results: [],
+        summary: {
+          created: 0,
+          updated: 0,
+          total: 0,
+        },
+      };
+
+      mockRankingScoreService.createMultipleRankingScores.mockResolvedValue(expectedResult);
+
+      const result = await controller.createMultipleRankingScores(
+        rankingId,
+        rankingItemId,
+        createMultipleScoresDto,
+        'user-id'
+      );
+
+      expect(service.createMultipleRankingScores).toHaveBeenCalledWith({
+        ...createMultipleScoresDto,
+        rankingItemId: 'item-id',
+        userId: 'user-id',
+      });
       expect(result).toEqual(expectedResult);
     });
   });

--- a/src/ranking/controllers/ranking-score.controller.ts
+++ b/src/ranking/controllers/ranking-score.controller.ts
@@ -11,6 +11,7 @@ import { AuthGuard } from '@nestjs/passport';
 import { ApiTags, ApiOperation, ApiResponse, ApiParam, ApiBearerAuth, ApiBody } from '@nestjs/swagger';
 import { RankingScoreService } from '../services/ranking-score.service';
 import CreateRankingItemScoreDto from '../dto/create-ranking-item-score.dto';
+import CreateMultipleRankingItemScoresDto from '../dto/create-multiple-ranking-item-scores.dto';
 import { GetUser } from 'src/user/decorators/get-current-user.decorator';
 
 @ApiTags('Ranking Scores')
@@ -156,6 +157,120 @@ export class RankingScoreController {
     Logger.log('Getting ranking scores', RankingScoreController.name);
     return await this.rankingItemScoreService.getRankingItemScores(
       rankingItemId,
+    );
+  }
+
+  @Post(':rankingId/items/:rankingItemId/scores/bulk')
+  @ApiOperation({ summary: 'Create multiple scores for a ranking item at once' })
+  @ApiParam({ name: 'rankingId', description: 'ID of the ranking' })
+  @ApiParam({ name: 'rankingItemId', description: 'ID of the ranking item' })
+  @ApiBody({
+    description: 'Payload to create/update multiple scores for different criteria',
+    schema: {
+      type: 'object',
+      properties: {
+        scores: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              rankingCriteriaId: { type: 'string', example: 'criteria-123' },
+              score: { type: 'number', minimum: 0, maximum: 10, example: 8 },
+            },
+            required: ['rankingCriteriaId', 'score'],
+          },
+          example: [
+            { rankingCriteriaId: 'criteria-123', score: 8 },
+            { rankingCriteriaId: 'criteria-456', score: 9 },
+            { rankingCriteriaId: 'criteria-789', score: 7 },
+          ],
+        },
+      },
+      required: ['scores'],
+    },
+  })
+  @ApiResponse({
+    status: 201,
+    description: 'Multiple scores created/updated successfully',
+    schema: {
+      properties: {
+        message: { type: 'string', example: '3 score(s) processado(s) com sucesso' },
+        results: {
+          type: 'array',
+          items: {
+            properties: {
+              id: { type: 'string', example: 'score-123' },
+              score: { type: 'number', example: 8 },
+              rankingItemId: { type: 'string', example: 'item-123' },
+              rankingCriteriaId: { type: 'string', example: 'criteria-123' },
+              userId: { type: 'string', example: 'user-123' },
+              createdAt: { type: 'string', format: 'date-time', example: '2024-07-01T12:00:00.000Z' },
+              action: { type: 'string', enum: ['created', 'updated'], example: 'created' },
+            },
+          },
+        },
+        summary: {
+          properties: {
+            created: { type: 'number', example: 2 },
+            updated: { type: 'number', example: 1 },
+            total: { type: 'number', example: 3 },
+          },
+        },
+      },
+      example: {
+        message: '3 score(s) processado(s) com sucesso',
+        results: [
+          {
+            id: 'score-123',
+            score: 8,
+            rankingItemId: 'item-123',
+            rankingCriteriaId: 'criteria-123',
+            userId: 'user-123',
+            createdAt: '2024-07-01T12:00:00.000Z',
+            action: 'created',
+          },
+          {
+            id: 'score-456',
+            score: 9,
+            rankingItemId: 'item-123',
+            rankingCriteriaId: 'criteria-456',
+            userId: 'user-123',
+            createdAt: '2024-07-01T12:00:00.000Z',
+            action: 'updated',
+          },
+        ],
+        summary: {
+          created: 1,
+          updated: 1,
+          total: 2,
+        },
+      },
+    },
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'Bad request - validation error',
+    schema: { example: { message: 'Erro de validação' } },
+  })
+  async createMultipleRankingScores(
+    @Param('rankingId') rankingId: string,
+    @Param('rankingItemId') rankingItemId: string,
+    @Body() createMultipleScoresDto: CreateMultipleRankingItemScoresDto,
+    @GetUser() userId: string,
+  ) {
+    Logger.log('Request', {
+      rankingId,
+      rankingItemId,
+      createMultipleScoresDto,
+      userId,
+    });
+
+    Logger.log('Creating multiple ranking scores', RankingScoreController.name);
+    createMultipleScoresDto.rankingItemId = rankingItemId;
+    createMultipleScoresDto.userId = userId;
+
+    return await this.rankingItemScoreService.createMultipleRankingScores(
+      createMultipleScoresDto,
     );
   }
 }

--- a/src/ranking/dto/create-multiple-ranking-item-scores.dto.ts
+++ b/src/ranking/dto/create-multiple-ranking-item-scores.dto.ts
@@ -1,0 +1,32 @@
+import { IsArray, IsNotEmpty, IsNumber, ValidateNested } from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class ScoreDto {
+  @IsNotEmpty({
+    message: 'ID do critério não pode ser vazio 💁',
+  })
+  rankingCriteriaId: string;
+
+  @IsNotEmpty({
+    message: 'Pontuação não pode ser vazia 💁',
+  })
+  @IsNumber(
+    {},
+    {
+      message: 'Pontuação precisa ser um número 🤷',
+    },
+  )
+  score: number;
+}
+
+export default class CreateMultipleRankingItemScoresDto {
+  rankingItemId: string;
+  userId: string;
+
+  @IsArray({
+    message: 'Scores deve ser um array 📝',
+  })
+  @ValidateNested({ each: true })
+  @Type(() => ScoreDto)
+  scores: ScoreDto[];
+}

--- a/src/ranking/services/ranking-score.service.ts
+++ b/src/ranking/services/ranking-score.service.ts
@@ -2,8 +2,20 @@ import { BadRequestException, Injectable } from '@nestjs/common';
 import { RankingValidationsService } from './ranking-validations.service';
 import { RankingScoreRepository } from '../repositories/ranking-score.repository';
 import CreateRankingItemScoreDto from '../dto/create-ranking-item-score.dto';
+import CreateMultipleRankingItemScoresDto, { ScoreDto } from '../dto/create-multiple-ranking-item-scores.dto';
 import { RankingUserRepository } from '../repositories/ranking-user.repository';
 import { ExpoPushService } from 'src/shared/services/expo-push.service';
+
+type ScoreResult = {
+  action: 'created' | 'updated';
+  id: string;
+  createdAt: Date;
+  updatedAt: Date;
+  userId: string;
+  rankingItemId: string;
+  score: number;
+  rankingCriteriaId: string;
+};
 
 @Injectable()
 export class RankingScoreService {
@@ -130,5 +142,121 @@ export class RankingScoreService {
         'Não foi possível atualizar a pontuação do item do ranking 😔',
       );
     }
+  }
+
+  async createMultipleRankingScores(createMultipleScoresDto: CreateMultipleRankingItemScoresDto) {
+    try {
+      const { rankingItemId, userId, scores } = createMultipleScoresDto;
+
+      // Executar validação e busca do ranking item em paralelo
+      const [rankingItem] = await Promise.all([
+        this.rankingValidationsService.existRankingItem(rankingItemId),
+        this.validateMultipleScoresRequest(rankingItemId, scores),
+      ]);
+      
+      const results = await this.processMultipleScores(rankingItemId, userId, scores);
+      
+      // Enviar notificação em paralelo com o retorno da resposta
+      const [response] = await Promise.all([
+        Promise.resolve(this.buildSuccessResponse(results)),
+        this.sendEvaluationNotification(rankingItem.rankingId, userId),
+      ]);
+
+      return response;
+    } catch (error) {
+      if (error instanceof BadRequestException) {
+        throw error;
+      }
+
+      throw new BadRequestException(
+        'Não foi possível criar/atualizar as pontuações do item do ranking 😔',
+      );
+    }
+  }
+
+  private async validateMultipleScoresRequest(rankingItemId: string, scores: ScoreDto[]) {
+    const criteriaIds = scores.map(score => score.rankingCriteriaId);
+    
+    // Validar todos os critérios em paralelo
+    await Promise.all(
+      criteriaIds.map(criteriaId => 
+        this.rankingValidationsService.existRankingCriteria(criteriaId)
+      )
+    );
+  }
+
+  private async processMultipleScores(
+    rankingItemId: string, 
+    userId: string, 
+    scores: ScoreDto[]
+  ): Promise<ScoreResult[]> {
+    // Processar todos os scores em paralelo para melhor performance
+    const scorePromises = scores.map(scoreData => 
+      this.processSingleScore(rankingItemId, userId, scoreData)
+    );
+
+    return Promise.all(scorePromises);
+  }
+
+  private async processSingleScore(
+    rankingItemId: string, 
+    userId: string, 
+    scoreData: ScoreDto
+  ): Promise<ScoreResult> {
+    const existingScore = await this.rankingValidationsService.existRankingItemCriteriaScore(
+      rankingItemId,
+      userId,
+      scoreData.rankingCriteriaId,
+    );
+
+    if (existingScore?.id) {
+      const updated = await this.rankingScoreRepository.updateRankingScore(
+        existingScore.id,
+        { score: scoreData.score },
+      );
+      return { ...updated, action: 'updated' as const };
+    }
+
+    const created = await this.rankingScoreRepository.createRankingScore({
+      userId,
+      score: scoreData.score,
+      rankingItemId,
+      rankingCriteriaId: scoreData.rankingCriteriaId,
+    });
+    return { ...created, action: 'created' as const };
+  }
+
+  private async sendEvaluationNotification(rankingId: string, userId: string) {
+    try {
+      const tokens = await this.rankingUserRepository.getRankingUsersPushTokens(
+        rankingId,
+        userId,
+      );
+      
+      if (tokens?.length > 0) {
+        await this.expoPushService.sendBulkPushNotifications(
+          tokens,
+          'Item avaliado 📝',
+          'Um item do ranking foi completamente avaliado.',
+        );
+      }
+    } catch {
+      // Silently ignore push notification errors
+    }
+  }
+
+  private buildSuccessResponse(results: ScoreResult[]) {
+    const createdCount = results.filter(r => r.action === 'created').length;
+    const updatedCount = results.filter(r => r.action === 'updated').length;
+
+    return {
+      message: `${results.length} score(s) processado(s) com sucesso`,
+      results,
+      summary: {
+        created: createdCount,
+        updated: updatedCount,
+        total: results.length,
+      },
+    };
   }
 }


### PR DESCRIPTION
- Implemented `createMultipleRankingScores` method in `RankingScoreController` and `RankingScoreService` to handle the creation of multiple scores for a ranking item in a single request.
- Introduced `CreateMultipleRankingItemScoresDto` to define the structure of the request payload.
- Added unit tests to ensure functionality and error handling for the new feature, including validation for existing scores and push notification logic.
- Enhanced API documentation for the new endpoint to provide clear usage instructions.