### PR TITLE
feat: add deletedAt column for soft delete in Ranking table

### DIFF
--- a/prisma/migrations/20250924075422_add_soft_delete_to_ranking /migration.sql
+++ b/prisma/migrations/20250924075422_add_soft_delete_to_ranking /migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Ranking" ADD COLUMN     "deletedAt" TIMESTAMP(3);


### PR DESCRIPTION
- Introduced a new column `deletedAt` of type TIMESTAMP(3) to the `Ranking` table to support soft delete functionality.